### PR TITLE
fix: follow google photos change (#13)

### DIFF
--- a/src/impl.ts
+++ b/src/impl.ts
@@ -11,12 +11,8 @@ export async function getSharedAlbumHtml(albumSharedurl: string, signal?: AbortS
   }).then(r => r.data);
 }
 export function parsePhase1(input: string): string | null {
-  const re = /<script nonce="[^"]+">AF_initDataCallback\((.+data\s*:\s*[^<]+})\s*\)\s*;\s*<\/script>/;
-  const s = re.exec(input);
-  if (null === s || s.length !== 2) {
-    return null;
-  }
-  return s[1];
+  const re = /(?<=AF_initDataCallback\()(?=.*data)(\{[\s\S]*?)(\);<\/script>)/g;
+  return [...input.matchAll(re)].reduce((a, b) => (a.length > b[1].length ? a : b[1]), '');
 }
 export function parsePhase2(input: string): unknown {
   try {


### PR DESCRIPTION
near 2023-03-26, Google changed the way to call AF_initDataCallback to twice.

As @Rafnuss suggests,  we decide to use the longest-length string.

close #13